### PR TITLE
Add update-all-members workflow

### DIFF
--- a/.github/workflows/update-all-members.yml
+++ b/.github/workflows/update-all-members.yml
@@ -1,0 +1,24 @@
+name: Update all changed member files
+
+on:
+  schedule:
+    - cron: "25 16 * * 1"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Fetch main branch
+        run: git fetch origin main:main
+      - name: Install npm packages
+        run: npm install
+      - name: Update all changed member files
+        run: bash ./bin/update-all-members
+      - name: Commit member changes, if any
+        run: bash ./bin/commit-member-changes


### PR DESCRIPTION
This workflow will run every Monday at 16:25 UTC, and it will attempt to fetch new JSON files for every member in `members.json`.

I chose this time based on these criteria:

* Inside working hours in both GMT/BST and EST/EDT, so we can fix anything that goes wrong.
* Not at the top of the hour, so avoids [peak times](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule).
* Once a week should be more than enough for data that is likely to change on the timescale of months.
* Tomorrow's Monday, so we can check that everything is working right.

Just a note: GitHub dictates that scheduled workflows can only run on `main`.

Also: we can always update the JSON files manually by running `./bin/update-all-members`.