### PR TITLE
Add member onboarding README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,69 @@
 
 _Brought to you by [Sentry](https://sentry.io/welcome/) and contributors._
 
-Open Source [is a
-restaurant](https://openpath.chadwhitacre.com/2024/open-source-is-a-restaurant/).
-Our companies feast at the table year after year. [Let's settle
-up](https://osspledge.com/).
+Open Source [is a restaurant][restaurant]. Our companies feast at the table year
+after year. [Let's settle up][osp].
+
+[osp]: https://osspledge.com/
+[restaurant]: https://openpath.chadwhitacre.com/2024/open-source-is-a-restaurant/
 
 ## Timeline
 
-- **September 1**—website launch 👉
-  **[osspledge.com](https://osspledge.com/)**
+- **September 1**—website launch 👉 **[osspledge.com][osp]**
 - **September 15**—member onboarding deadline to participate in a ...
 - **October 7–November 3**—major outdoor advertising campaign
 
-## Onboarding
+## Member Onboarding
 
-To help us build [Open Source Pledge](https://osspledge.com/), please
-[dive into our
-issues](https://github.com/opensourcepledge/osspledge.com/issues) or
-reach out to the working group leads listed below either in issues or [on
-Discord](https://discord.gg/svH5XzDsBd).
+Want to join the Pledge and contribute to a healthy Open Source ecosystem? We'd
+love to have you! :balloon:
 
-### Members
+Here's how to join:
 
-The Pledge is [under active
-development](https://github.com/opensourcepledge/osspledge.com/issues/4).
-We aim to publish a website by September 1, with instructions on how your
-company can publish your Pledge report with us. In the mean time, **pay Open
-Source maintainers**. The minimum to participate in the Pledge is $2,000 per
-year per full-time developer on staff.
+1. **Donate $2,000 per full-time developer on staff** to Open Source projects of
+   your choice, and commit to doing so in future years. The projects you're
+   donating to should meet the [Open Source Definition][osd]. Of course, this
+   includes any existing donations you've made this fiscal year. You can donate
+   to any projects you like, but if you need help figuring out which projects
+   you depend on, you can use a tool like [Thanks.dev](https://thanks.dev/).
+2. **Create a short JSON file with your company and donation info**, and host it
+   at any URL you wish. You can check out an [example JSON
+   report][example-report] or the [full schema][schema]. You should update this
+   JSON file at least yearly — we'll fetch it regularly. We understand your
+   fiscal year might end on various dates — you can record the end date of your
+   fiscal year in the `dateYearEnding` field.
+3. **Create a pull request to add yourself to the member list** by changing
+   [members.csv][members-csv].
+4. **Include links to your branding materials** in the pull request so that we
+   can promote you! For those pledging before September 15, this means you'll be
+   included in our major outdoor advertising campaign.
 
-### Maintainers
+Once that's all done, you'll officially be a member. This means that your
+company and reports will show up on [our website][osp], and you'll be entitled
+to use the [Open Source Pledge Member logo][member-logo] on your website and
+marketing materials if you wish. Thank you so much for joining us in
+contributing to a healthy Open Source ecosystem that supports maintainers.
+
+If you have any questions, feel free to [open an issue][new-issue], and the
+relevant member of our team will get back to you.
+
+[osd]: https://opensource.org/osd
+[example-report]: https://github.com/opensourcepledge/osspledge.com/blob/main/contrib/example-schema.json
+[schema]: https://github.com/opensourcepledge/osspledge.com/blob/main/src/content/config.ts
+[members-csv]: https://github.com/opensourcepledge/osspledge.com/blob/main/members.csv
+[member-logo]: https://github.com/opensourcepledge/osspledge.com/tree/main/public/logos
+[new-issue]: https://github.com/opensourcepledge/osspledge.com/issues/new
+
+## Want to Help?
+
+To help us build [Open Source Pledge][osp], please [dive into our
+issues][issues] or reach out to the working group leads listed below either in
+issues or [on Discord][discord].
+
+[issues]: https://github.com/opensourcepledge/osspledge.com/issues
+[discord]: https://discord.gg/svH5XzDsBd
+
+## Maintainers
 
 Open Source Pledge is not involved in any flow of funds and so we do not
 directly onboard maintainers. We encourage you to onboard to the following


### PR DESCRIPTION
I'm sure there are ways to improve this, let me know if I've left out any important details!

You can read the rendered version by visiting [the branch](https://github.com/opensourcepledge/osspledge.com/tree/vladh/add-member-onboarding-readme).

Fixes #31.