### PR TITLE
Add HTTP Toolkit to members.csv

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -3,3 +3,4 @@ astral,https://astral.sh/static/osspledge.json
 val-town,https://std-oss_pledge.web.val.run
 scalar,https://raw.githubusercontent.com/scalar/scalar/main/oss-pledge.json
 gitbutler,https://docs.gitbutler.com/oss/pledge.json
+httptoolkit,https://httptoolkit.com/data/oss-pledge.json


### PR DESCRIPTION
Adding HTTP Toolkit to the members list :smiley:

The README says "Include links to your branding materials" - unclear exactly what materials you'd like, but here's a selection:

* [High res logo with transparent background](https://github.com/user-attachments/assets/fd572f77-e80f-4a16-b4f2-43879afcd920)
* [Logo + text with transparent background](https://github.com/user-attachments/assets/2af626f6-94e7-49de-9165-2a03ea135ac0)
* [Full brand book](https://github.com/user-attachments/files/16512994/Http.Toolkit.-.Brand.Guidelines.pdf)

~~This doesn't match the current website yet, there's a pending brand update that I'll be rolling out in just a few weeks which tweaks things in a few places, but it'll all match up nicely soon. I have no problem with these being published & visible in places before that's live, but if you'd prefer current materials in the meantime let me know.~~