### PR TITLE
Add leaderboards

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -1,2 +1,1 @@
 sentry,https://raw.githubusercontent.com/opensourcepledge/osspledge.com/main/contrib/example-schema.json
-newtest,https://raw.githubusercontent.com/opensourcepledge/osspledge.com/main/contrib/example-schema.json

--- a/public/example-member-0.svg
+++ b/public/example-member-0.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#1d1f3b;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#a69ccd;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-1.svg
+++ b/public/example-member-1.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#551122;fill-opacity:1"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#9ccdac;fill-opacity:1"
+       id="path1"
+       cx="52.916672"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-10.svg
+++ b/public/example-member-10.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#323b1d;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#cdc69c;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-2.svg
+++ b/public/example-member-2.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#11553d;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#9ccdac;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-3.svg
+++ b/public/example-member-3.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#1d2f3b;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#a19ccd;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-4.svg
+++ b/public/example-member-4.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#381d3b;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#cdbe9c;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-5.svg
+++ b/public/example-member-5.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#1d3b2a;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#cdbe9c;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-6.svg
+++ b/public/example-member-6.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#231d3b;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#9ccdca;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-7.svg
+++ b/public/example-member-7.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#1d313b;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#a99ccd;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-8.svg
+++ b/public/example-member-8.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#1d363b;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#cd9cbe;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/public/example-member-9.svg
+++ b/public/example-member-9.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="400"
+   height="400"
+   viewBox="0 0 105.83333 105.83333"
+   version="1.1"
+   id="svg1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <g
+     id="layer1">
+    <rect
+       style="fill:#1d1f3b;fill-opacity:1;stroke-width:0.392517"
+       id="rect1"
+       width="105.83334"
+       height="105.83334"
+       x="-3.5527137e-15"
+       y="0" />
+    <circle
+       style="fill:#cd9ca5;fill-opacity:1;stroke-width:0.365509"
+       id="path1"
+       cx="52.916668"
+       cy="-52.916668"
+       r="41.466705"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/src/components/Leaderboard.astro
+++ b/src/components/Leaderboard.astro
@@ -1,0 +1,104 @@
+---
+interface Props {
+  grouped: boolean;
+}
+
+const { grouped } = Astro.props;
+
+import { getMembers, getDollarsPerDev, fmtCurrency } from '../member_util.ts';
+import type { MemberWithId } from "../content/config.ts";
+
+const members = await getMembers();
+
+/**
+ * The groups members will be sorted into when `groupMembers()` is used.
+ * This is a list of the maximum and minimum developer count for each group,
+ * inclusive. So, `[[1, 100], [101, 500]]` means that a company with 100
+ * developers will be placed in the first group, but a company with 101
+ * developers will be placed in the second one, and so on.
+ */
+const DEV_GROUP_BOUNDS: [number, number][] = [
+  [Infinity, 25001],
+  [25000, 10001],
+  [10000, 1001],
+  [1001, 100],
+  [100, 1],
+];
+
+function formatDevGroupBounds([max, min]: [number, number]) {
+  if (max == Infinity) {
+    return `${min} developers or more`;
+  } else {
+    return `${min} to ${max} developers`;
+  }
+}
+
+function filterInactiveMembers(members: MemberWithId[]): MemberWithId[] {
+  return members.filter((m) => m.data.annualReports.length > 0);
+}
+
+/**
+ * Puts members into groups based on the dollars per dev donated in their latest
+ * annual report, where the groups are set out by `DEV_GROUP_BOUNDS`.
+ */
+function groupMembers(members: MemberWithId[]): MemberWithId[][] {
+  let groups: MemberWithId[][] = DEV_GROUP_BOUNDS.map(() => []);
+  for (let member of members) {
+    const dpd = getDollarsPerDev(member.data.annualReports[0]);
+    const nDevs = member.data.annualReports[0].averageNumberOfDevs;
+    for (let idx in DEV_GROUP_BOUNDS) {
+      const [max, min] = DEV_GROUP_BOUNDS[idx];
+      if ((nDevs <= max || max == Infinity) && nDevs >= min) {
+        groups[idx].push(member);
+        break;
+      }
+    }
+  }
+  return groups;
+}
+
+/**
+ * Sorts members by the dollars per dev donated in their latest annual report.
+ */
+function sortMembers(members: MemberWithId[]): MemberWithId[] {
+  return members.toSorted((m1, m2) => {
+    if (m1.data.annualReports.length == 0) {
+      return 1;
+    }
+    if (m2.data.annualReports.length == 0) {
+      return -1;
+    }
+    const dpd1 = getDollarsPerDev(m1.data.annualReports[0]);
+    const dpd2 = getDollarsPerDev(m2.data.annualReports[0]);
+    return dpd2 - dpd1;
+  });
+}
+---
+<div class="leaderboard">
+  {grouped ? (
+    groupMembers(filterInactiveMembers(members)).map((groupMembers, idx) => groupMembers.length > 0 && <div>
+      <h3>{formatDevGroupBounds(DEV_GROUP_BOUNDS[idx])}</h3>
+      <table>
+        <tr>
+          <th class="text-left">Member name</th>
+          <th class="text-right">$/dev in latest report</th>
+        </tr>
+        {sortMembers(groupMembers).map((member) => <tr>
+          <td class="text-left">{member.data.name}</td>
+          <td class="text-right">{fmtCurrency(getDollarsPerDev(member.data.annualReports[0]))}</td>
+        </tr>)}
+      </table>
+    </div>)
+  ) : (
+    <table>
+      <tr>
+        <th class="text-left">Member name</th>
+        <th class="text-right">$/dev in latest report</th>
+      </tr>
+      {sortMembers(filterInactiveMembers(members)).map((member) => <tr>
+        <td class="text-left">{member.data.name}</td>
+        <td class="text-right">{fmtCurrency(getDollarsPerDev(member.data.annualReports[0]))}</td>
+      </tr>)}
+    </table>
+  )}
+</div>

--- a/src/components/Leaderboard.astro
+++ b/src/components/Leaderboard.astro
@@ -77,7 +77,7 @@ function sortMembers(members: MemberWithId[]): MemberWithId[] {
 ---
 <div class="leaderboard">
   {grouped ? <div>
-    <h2 class="m-0">Member Company Explorer</h2>
+    <h2 class="m-0">Member Companies</h2>
     {groupMembers(filterInactiveMembers(members)).map((groupMembers, idx) => groupMembers.length > 0 && <div>
       <table class="my-4">
         <tr class="border-none">

--- a/src/components/Leaderboard.astro
+++ b/src/components/Leaderboard.astro
@@ -77,7 +77,7 @@ function sortMembers(members: MemberWithId[]): MemberWithId[] {
 ---
 <div class="leaderboard">
   {grouped ? <div>
-    <h2 class="m-0">Member Leaderboard</h2>
+    <h2 class="m-0">Member Company Explorer</h2>
     {groupMembers(filterInactiveMembers(members)).map((groupMembers, idx) => groupMembers.length > 0 && <div>
       <table class="my-4">
         <tr class="border-none">

--- a/src/components/Leaderboard.astro
+++ b/src/components/Leaderboard.astro
@@ -5,7 +5,8 @@ interface Props {
 
 const { grouped } = Astro.props;
 
-import { getMembers, getDollarsPerDev, fmtCurrency } from '../member_util.ts';
+import LeaderboardMember from "./LeaderboardMember.astro";
+import { getMembers, getDollarsPerDev } from '../member_util.ts';
 import type { MemberWithId } from "../content/config.ts";
 
 const members = await getMembers();
@@ -75,29 +76,27 @@ function sortMembers(members: MemberWithId[]): MemberWithId[] {
 }
 ---
 <div class="leaderboard">
-  {grouped ? (
-    groupMembers(filterInactiveMembers(members)).map((groupMembers, idx) => groupMembers.length > 0 && <div>
-      <h3>{formatDevGroupBounds(DEV_GROUP_BOUNDS[idx])}</h3>
-      <table>
-        <tr>
-          <th class="text-left">Member name</th>
-          <th class="text-right">$/dev in latest report</th>
+  {grouped ? <div>
+    <h2 class="m-0">Member Leaderboard</h2>
+    {groupMembers(filterInactiveMembers(members)).map((groupMembers, idx) => groupMembers.length > 0 && <div>
+      <table class="my-4">
+        <tr class="border-none">
+          <th class="text-left pb-4"><h3 class="m-0">{formatDevGroupBounds(DEV_GROUP_BOUNDS[idx])}</h3></th>
+          <th class="text-right pb-4">$/dev in latest report</th>
         </tr>
-        {sortMembers(groupMembers).map((member) => <tr>
-          <td class="text-left">{member.data.name}</td>
-          <td class="text-right">{fmtCurrency(getDollarsPerDev(member.data.annualReports[0]))}</td>
+        {sortMembers(groupMembers).map((member) => <tr class="border-none">
+          <LeaderboardMember member={member}></LeaderboardMember>
         </tr>)}
       </table>
-    </div>)
-  ) : (
-    <table>
-      <tr>
-        <th class="text-left">Member name</th>
-        <th class="text-right">$/dev in latest report</th>
+    </div>)}
+  </div> : (
+    <table class="my-4">
+      <tr class="border-none">
+        <th class="text-left pb-4"><h2 class="m-0">Member Leaderboard</h2></th>
+        <th class="text-right pb-4">$/dev in latest report</th>
       </tr>
-      {sortMembers(filterInactiveMembers(members)).map((member) => <tr>
-        <td class="text-left">{member.data.name}</td>
-        <td class="text-right">{fmtCurrency(getDollarsPerDev(member.data.annualReports[0]))}</td>
+      {sortMembers(filterInactiveMembers(members)).map((member) => <tr class="border-none">
+        <LeaderboardMember member={member}></LeaderboardMember>
       </tr>)}
     </table>
   )}

--- a/src/components/LeaderboardMember.astro
+++ b/src/components/LeaderboardMember.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  member: Member;
+}
+
+const { member } = Astro.props;
+
+import { getDollarsPerDev, fmtCurrency } from '../member_util.ts';
+import type { Member } from "../content/config.ts";
+---
+<td class="text-left p-0 pb-2">
+  <div class="flex items-center">
+    <img src={member.data.urlSquareLogoWithBackground} class="w-14 h-14 m-0 mr-4">
+    {member.data.name}
+  </div>
+</td>
+<td class="text-right p-0 pb-2 align-middle">
+  {fmtCurrency(getDollarsPerDev(member.data.annualReports[0]))}
+</td>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -38,6 +38,10 @@ const member = z.object({
 
 export type Member = z.infer<typeof member>;
 export type MemberReport = z.infer<typeof memberReport>;
+export interface MemberWithId {
+  id: string,
+  data: Member,
+}
 
 export const collections = {
   members: defineCollection({

--- a/src/member_util.ts
+++ b/src/member_util.ts
@@ -1,0 +1,49 @@
+import { getCollection } from 'astro:content';
+import type { MemberReport } from "./content/config.ts";
+import exampleMember from '../contrib/example-schema.json';
+
+const isDev = import.meta.env.DEV;
+
+export async function getMembers() {
+  if (isDev) {
+    // In development mode, generate some mock data for testing.
+    const mockDevCounts = [
+      1, 34, 79, 230, 1004, 4052, 10245, 11245, 17353, 21324, 50124,
+    ]
+    return mockDevCounts.map((mockDevCount) => {
+      let newMember = structuredClone(exampleMember);
+      newMember.name = `Sentry ${mockDevCount}`;
+      newMember.annualReports = newMember.annualReports.map((report) => {
+        report.averageNumberOfDevs = mockDevCount;
+        return report;
+      });
+      return {
+        id: `sentry-${mockDevCount}`,
+        data: newMember,
+      };
+    });
+  } else {
+    return getCollection('members');
+  }
+}
+
+export function getReportCashTotal(report: MemberReport) {
+  return report.monetaryPayments
+    .map((d) => d.amount)
+    .reduce((acc, d) => acc + d, 0);
+}
+
+export function getReportFullTotal(report: MemberReport) {
+  return getReportCashTotal(report) + report.monetaryValueOfTime + report.monetaryValueOfMaterials;
+}
+
+export function getDollarsPerDev(report: MemberReport) {
+  return getReportCashTotal(report) / report.averageNumberOfDevs;
+}
+
+export function fmtCurrency(num: number) {
+  return '$' + num.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}

--- a/src/member_util.ts
+++ b/src/member_util.ts
@@ -14,7 +14,7 @@ function getMockMembers() {
   return mockDevCounts.map((mockDevCount, idx) => {
     let newMember = structuredClone(exampleMember);
     newMember.name = `Example Member (${mockDevCount} ${mockDevCount == 1 ? "Dev" : "Devs"})`;
-    newMember.urlSquareLogoWithBackground = `example-member-${idx}.svg`;
+    newMember.urlSquareLogoWithBackground = `/example-member-${idx}.svg`;
     newMember.annualReports = newMember.annualReports.map((report) => {
       report.averageNumberOfDevs = mockDevCount;
       return report;

--- a/src/member_util.ts
+++ b/src/member_util.ts
@@ -4,24 +4,31 @@ import exampleMember from '../contrib/example-schema.json';
 
 const isDev = import.meta.env.DEV;
 
+/**
+ * Generates some member data for testing to be used in dev mode.
+ */
+function getMockMembers() {
+  const mockDevCounts = [
+    1, 34, 79, 230, 1004, 4052, 10245, 11245, 17353, 21324, 50124,
+  ]
+  return mockDevCounts.map((mockDevCount, idx) => {
+    let newMember = structuredClone(exampleMember);
+    newMember.name = `Example Member (${mockDevCount} ${mockDevCount == 1 ? "Dev" : "Devs"})`;
+    newMember.urlSquareLogoWithBackground = `example-member-${idx}.svg`;
+    newMember.annualReports = newMember.annualReports.map((report) => {
+      report.averageNumberOfDevs = mockDevCount;
+      return report;
+    });
+    return {
+      id: `example-member-${idx}`,
+      data: newMember,
+    };
+  });
+}
+
 export async function getMembers() {
   if (isDev) {
-    // In development mode, generate some mock data for testing.
-    const mockDevCounts = [
-      1, 34, 79, 230, 1004, 4052, 10245, 11245, 17353, 21324, 50124,
-    ]
-    return mockDevCounts.map((mockDevCount) => {
-      let newMember = structuredClone(exampleMember);
-      newMember.name = `Sentry ${mockDevCount}`;
-      newMember.annualReports = newMember.annualReports.map((report) => {
-        report.averageNumberOfDevs = mockDevCount;
-        return report;
-      });
-      return {
-        id: `sentry-${mockDevCount}`,
-        data: newMember,
-      };
-    });
+    return getMockMembers();
   } else {
     return getCollection('members');
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import Prose from "../components/Prose.astro";
 import Button from "../components/Button.astro";
+import Leaderboard from "../components/Leaderboard.astro";
 ---
 
 <Layout title="Open Source Pledge" navless={true}>
@@ -65,6 +66,11 @@ import Button from "../components/Button.astro";
       <p class="my-8">
         Brought to you by <a href="https://sentry.io/welcome/">Sentry</a>.
       </p>
+
+      {import.meta.env.DEV && (
+        <h2>Member Leaderboard</h2>
+        <Leaderboard grouped={true}></Leaderboard>
+      )}
     </Prose>
   </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,6 @@
 import Layout from "../layouts/Layout.astro";
 import Prose from "../components/Prose.astro";
 import Button from "../components/Button.astro";
-import Leaderboard from "../components/Leaderboard.astro";
 ---
 
 <Layout title="Open Source Pledge" navless={true}>
@@ -66,10 +65,6 @@ import Leaderboard from "../components/Leaderboard.astro";
       <p class="my-8">
         Brought to you by <a href="https://sentry.io/welcome/">Sentry</a>.
       </p>
-
-      {import.meta.env.DEV && (
-        <Leaderboard grouped={true}></Leaderboard>
-      )}
     </Prose>
   </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,7 +68,6 @@ import Leaderboard from "../components/Leaderboard.astro";
       </p>
 
       {import.meta.env.DEV && (
-        <h2>Member Leaderboard</h2>
         <Leaderboard grouped={true}></Leaderboard>
       )}
     </Prose>

--- a/src/pages/members/[id].astro
+++ b/src/pages/members/[id].astro
@@ -39,7 +39,7 @@ function getPlatformName(url: string) {
         class="h-28 m-0 mr-8"
         src={member.urlSquareLogoWithBackground}
       >
-      <h2 class="text-6xl m-0">
+      <h2 class="text-4xl m-0">
         {member.name}
         <small class="block text-base font-normal pt-2">Open Source Pledge Member</small>
       </h2>

--- a/src/pages/members/[id].astro
+++ b/src/pages/members/[id].astro
@@ -1,6 +1,8 @@
 ---
-import { getCollection } from 'astro:content';
-import type { Member, MemberReport } from "../../content/config.ts";
+import {
+  getMembers, getReportCashTotal, getReportFullTotal, getDollarsPerDev, fmtCurrency
+} from '../../member_util.ts';
+import type { Member } from "../../content/config.ts";
 import Layout from "../../layouts/Layout.astro";
 import Prose from "../../components/Prose.astro";
 
@@ -11,7 +13,7 @@ interface Props {
 const { member } = Astro.props;
 
 export async function getStaticPaths() {
-  const memberItems = await getCollection('members');
+  const memberItems = await getMembers();
   return memberItems.map(({ id, data }: { id: string, data: Member }) => {
     return { params: { id }, props: { member: data } };
   });
@@ -28,27 +30,6 @@ function getPlatformName(url: string) {
   } catch (err) {
   }
   return platformNames.get(host) || 'Other';
-}
-
-function getReportCashTotal(report: MemberReport) {
-  return report.monetaryPayments
-    .map((d) => d.amount)
-    .reduce((acc, d) => acc + d, 0);
-}
-
-function getReportFullTotal(report: MemberReport) {
-  return getReportCashTotal(report) + report.monetaryValueOfTime + report.monetaryValueOfMaterials;
-}
-
-function getDollarsPerDev(report: MemberReport) {
-  return getReportCashTotal(report) / report.averageNumberOfDevs;
-}
-
-function fmtCurrency(num: number) {
-  return '$' + num.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
 }
 ---
 <Layout title="Open Source Pledge" navless={false}>

--- a/src/pages/members/index.astro
+++ b/src/pages/members/index.astro
@@ -1,0 +1,11 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import Prose from "../../components/Prose.astro";
+import Leaderboard from "../../components/Leaderboard.astro";
+---
+
+<Layout title="Open Source Pledge" navless={false}>
+  <Prose>
+    <Leaderboard grouped={true}></Leaderboard>
+  </Prose>
+</Layout>


### PR DESCRIPTION
This PR adds leaderboards, which are currently only visible in the development environment, i.e. will not show up on the deployed website. The leaderboards currently use some auto-generated dummy data, because we don't have enough members to accurately test them.

The leaderboard lives in the `Leaderboard` component, which has two possible features. With `grouped={false}`, the leaderboard is ungrouped, which means that it simply displays a list of all members sorted by their latest $/dev amount. With `grouped={true}`, the leaderboard is grouped into brackets depending on developer count, which can be defined in `DEV_GROUP_BOUNDS`.

Note that, because annual reports can happen at different times and based on different fiscal years, the amounts listed in the leaderboard for each company might have been declared up to a year apart from each other, so this is a best-effort comparison.

Also, the example avatars I added can be removed at any time in the future, they are 500 bytes each.

Fixes #42.

![2024-08-07-19-41-02](https://github.com/user-attachments/assets/ec31226f-10ec-40a4-8fda-fa0084186ace)

![2024-08-07-19-41-12](https://github.com/user-attachments/assets/728b9c69-300f-4ae9-94ef-cfb5b4216305)