### PR TITLE
doc: reduce bias in funding platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ open source projects.
 - [Open Collective](https://opencollective.com/)
 - [Patreon](https://www.patreon.com/)
 - [Polar](https://www.polar.sh/)
+- [Software Freedom Conservancy (SFC)](https://sfconservancy.org/projects/apply/)
+- [Software in the Public Interest (SPI)](https://www.spi-inc.org/projects/)
 - [StackAid](https://www.stackaid.us/)
 - [Thanks.dev](https://thanks.dev/)
 - [Tidelift](https://tidelift.com/)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ open source projects.
 - [Patreon](https://www.patreon.com/)
 - [Polar](https://www.polar.sh/)
 - [Software Freedom Conservancy (SFC)](https://sfconservancy.org/projects/apply/)
-- [Software in the Public Interest (SPI)](https://www.spi-inc.org/projects/)
+- [Software in the Public Interest (SPI)](https://www.spi-inc.org/projects/associated-project-howto/)
 - [StackAid](https://www.stackaid.us/)
 - [Thanks.dev](https://thanks.dev/)
 - [Tidelift](https://tidelift.com/)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For projects that do not have existing ways to recieve funds, the following is
 a partial list of platforms, in alphabetical order only, that enable funding of
 open source projects.
 
+- [Apache Software Foundation: Incubator](https://incubator.apache.org/)
 - [Buy Me a Coffee](https://www.buymeacoffee.com/)
 - [GitHub Sponsors](https://github.com/sponsors)
 - [IssueHunt](https://issuehunt.io/)

--- a/README.md
+++ b/README.md
@@ -81,14 +81,9 @@ issues or [on Discord][discord].
 ## Maintainers
 
 Open Source Pledge is not involved in any flow of funds and so we do not
-directly onboard maintainers. Please confirm with each open source project
-about their individual best means of recieving funds, as platforms and fiscal
-hosts have varying fee structures, and the recipient projects may have specific
-ways to maximize the impact of your contributions.
-
-For projects that do not have existing ways to recieve funds, the following is
-a partial list of platforms, in alphabetical order only, that enable funding of
-open source projects.
+directly onboard maintainers. For projects that do not have existing ways to
+recieve funds, the following is a partial list of platforms, in alphabetical
+order only, that enable funding of open source projects.
 
 - [Apache Software Foundation: Incubator](https://incubator.apache.org/)
 - [Buy Me a Coffee](https://www.buymeacoffee.com/)

--- a/README.md
+++ b/README.md
@@ -81,8 +81,14 @@ issues or [on Discord][discord].
 ## Maintainers
 
 Open Source Pledge is not involved in any flow of funds and so we do not
-directly onboard maintainers. We encourage you to onboard to the following
-platforms to receive funding from Open Source Pledge Members:
+directly onboard maintainers. Please confirm with each open source project
+about their individual best means of recieving funds, as platforms and fiscal
+hosts have varying fee structures, and the recipient projects may have specific
+ways to maximize the impact of your contributions.
+
+For projects that do not have existing ways to recieve funds, the following is
+a partial list of platforms, in alphabetical order only, that enable funding of
+open source projects.
 
 - [Buy Me a Coffee](https://www.buymeacoffee.com/)
 - [GitHub Sponsors](https://github.com/sponsors)


### PR DESCRIPTION
As documented in #50, there is an implicit bias in the list of funding platforms. This PR attempts to improve that.

- doc: reduce bias in list of funding platforms
- doc: Funding platforms: add Apache Software Foundation
- doc: Funding platforms: add Software Freedom Conservancy (SFC)
- doc: Funding platforms: add Software in the Public Interest (SPI)

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
Reference: https://github.com/opensourcepledge/osspledge.com/issues/50