### PR TITLE
Tweak homepage headings

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,11 +11,10 @@ import Button from "../components/Button.astro";
         class="max-w-72 oss-logo"
         src="/logos/opensourcepledge-logo-horiz-color.png"
       />
-      <h1 class="text-white hero-header">Open Source Pledge</h1>
       <p class="text-app-muted"><em>Launching in October</em></p>
 
       <h2 class="text-white mt-8 mb-4 text-3xl font-bold">
-        What is Open Source?
+        The Economics of Open Source
       </h2>
       <p>
         Open Source is <a
@@ -35,7 +34,7 @@ import Button from "../components/Button.astro";
         to settle up.
       </p>
 
-      <h2 class="text-white mt-8 mb-4 text-3xl font-bold">How?</h2>
+      <h2 class="text-white mt-8 mb-4 text-3xl font-bold">How the Pledge Works</h2>
 
       <div class="highlight-box">
         <h3>Step One</h3>


### PR DESCRIPTION
Now that we have the logo, the H1 is redundant, and pushes the content too far down the page. Here's a temporary fix while we work on a larger site design.