### PR TITLE
Doesn't need to be a fiscal year

### DIFF
--- a/src/pages/join.astro
+++ b/src/pages/join.astro
@@ -4,18 +4,19 @@ import Prose from "../components/Prose.astro";
 import Button from "../components/Button.astro";
 ---
 
-<Layout title="Open Source Pledge" navless={true}>
- <div class="flex items-center min-h-screen">
+<Layout title="Open Source Pledge" navless="{true}">
+  <div class="flex items-center min-h-screen">
     <Prose>
-      <a href="/"><img
-        class="max-w-72 oss-logo"
-        src="/logos/opensourcepledge-logo-horiz-color.png"
-        /></a>
+      <a href="/"
+        ><img
+          class="max-w-72 oss-logo"
+          src="/logos/opensourcepledge-logo-horiz-color.png"
+      /></a>
 
       <h2>How to Join the Pledge</h2>
       <p>
-        Want to join the Pledge and contribute to a healthy Open Source ecosystem?
-        We’d love to have you! 🎈
+        Want to join the Pledge and contribute to a healthy Open Source
+        ecosystem? We’d love to have you! 🎈
       </p>
       <p>Here’s how to join:</p>
       <ol>
@@ -23,19 +24,20 @@ import Button from "../components/Button.astro";
           <strong
             >Donate $2,000 per full-time equivalent developer on staff</strong
           >
-          to Open Source maintainers or foundations of your choice, and commit to
-          doing so in future years. The projects you’re donating to should meet
-          the
+          to Open Source maintainers or
+          <a href="https://fossfoundation.info/">foundations</a> of your choice,
+          and commit to doing so in future years. The projects you’re donating
+          to should meet the
           <a href="https://opensource.org/osd">Open Source Definition</a>. Of
-          course, this includes any existing donations you’ve made this fiscal
-          year. You can donate to any projects you like, but if you need help
-          figuring out which projects you depend on, you can use a tool like
+          course, this includes any existing donations you’ve made this year.
+          You can donate to any projects you like, but if you need help figuring
+          out which projects you depend on, you can use a tool like
           <a href="https://thanks.dev">Thanks.dev</a>.
         </li>
         <li>
           <strong>Publish a blog post</strong>, or equivalent, on your company
           website, detailing the contributions your company has made to the Open
-          Source ecosystem this fiscal year. This post does not need to be long or
+          Source ecosystem the past year. This post does not need to be long or
           exhaustive. If in doubt, check out sample posts by
           <a
             href="https://blog.sentry.io/we-just-gave-500-000-dollars-to-open-source-maintainers/"
@@ -57,7 +59,8 @@ import Button from "../components/Button.astro";
         </li>
         <li>
           <strong
-            >Create a short JSON file with your company and donation info</strong
+            >Create a short JSON file with your company and donation
+            info</strong
           >, and host it at any URL you wish. You can check out an
           <a
             href="https://github.com/opensourcepledge/osspledge.com/blob/main/contrib/example-schema.json"
@@ -74,10 +77,10 @@ import Button from "../components/Button.astro";
               we’ll fetch it regularly.
             </li>
             <li>
-              All amounts are in USD so that different reports can be compared to
-              each other. If you’re using a different currency, you should convert
-              all amounts to the USD equivalents, using the most appropriate
-              exchange rate.
+              All amounts are in USD so that different reports can be compared
+              to each other. If you’re using a different currency, you should
+              convert all amounts to the USD equivalents, using the most
+              appropriate exchange rate.
             </li>
             <li><code>name</code>: The name of your company.</li>
             <li>
@@ -86,49 +89,48 @@ import Button from "../components/Button.astro";
               notes on your company’s relationship with Open Source software.
             </li>
             <li>
-              <code>urlLearnMore</code>: A URL not to your company’s homepage, but
-              to some kind of page that describes your relationship to Open Source
-              and/or your commitment to supporting Open Source. This page need not
-              be exhaustive.
+              <code>urlLearnMore</code>: A URL either to your company’s homepage
+              or, better yet, to some kind of page that describes your
+              relationship to Open Source and/or your commitment to supporting
+              Open Source. This page need not be exhaustive.
             </li>
             <li>
-              <code>urlSquareLogoWithBackground</code>: Your logo, which should be
-              square and have a non-transparent background. This image should be
-              between 400x400px and 800x800px, and should be appropriately
+              <code>urlSquareLogoWithBackground</code>: Your logo, which should
+              be square and have a non-transparent background. This image should
+              be between 400x400px and 800x800px, and should be appropriately
               compressed.
             </li>
             <li>
               Each <code>annualReport</code> should contain:
               <ul>
                 <li>
-                  <code>url</code>: The URL to the blog post for this fiscal year,
-                  as detailed above.
+                  <code>dateYearEnding</code>: The end date of the year you are
+                  reporting on.
                 </li>
                 <li>
-                  <code>dateYearEnding</code>: We understand your fiscal year
-                  might end on various dates — you can record the end date of your
-                  fiscal year in this field.
+                  <code>url</code>: The URL to the blog post for the year in
+                  question, as detailed above.
                 </li>
                 <li>
                   <code>averageNumberOfDevs</code>: The average number of
-                  full-time equivalent developers employed by your company during
-                  that fiscal year.
+                  full-time equivalent developers employed by your company
+                  during the year.
                 </li>
                 <li>
                   <code>payments</code>: The total US dollar amount of cash
-                  contributions you have made towards Open Source maintainers and
-                  foundations during this fiscal year.
+                  contributions you have made towards Open Source maintainers
+                  and foundations during the year.
                 </li>
                 <li>
                   <code>monetaryValueofTime</code>,
                   <code>monetaryValueOfMaterials</code>: You may also optionally
                   specify, in approximate US dollar equivalents, your
                   contributions to the Open Source ecosystem in sponsored
-                  developer time (in <code>monetaryValueOfTime</code>) or gifts in
-                  kind (in <code>monetaryValueOfMaterials</code>). While we
+                  developer time (in <code>monetaryValueOfTime</code>) or gifts
+                  in kind (in <code>monetaryValueOfMaterials</code>). While we
                   acknowledge that contributions in time and in kind are
-                  important, they are not included in the cash pledge amount. They
-                  will still be displayed on your member page.
+                  important, they are not included in the cash pledge amount.
+                  They will still be displayed on your member page.
                 </li>
               </ul>
             </li>
@@ -146,21 +148,21 @@ import Button from "../components/Button.astro";
         </li>
         <li>
           <strong>Include links to your branding materials</strong> in the pull
-          request so that we can promote you! For those pledging before September
-          15, this means you’ll be included in our major outdoor advertising
-          campaign.
+          request so that we can promote you! For those pledging before
+          September 15, this means you’ll be included in our major outdoor
+          advertising campaign.
         </li>
       </ol>
       <p>
-        Once that’s all done, you’ll officially be a member. This means that your
-        company and reports will show up on [our website][osp], and you’ll be
-        entitled to use the
+        Once that’s all done, you’ll officially be a member. This means that
+        your company and reports will show up on [our website][osp], and you’ll
+        be entitled to use the
         <a
           href="https://github.com/opensourcepledge/osspledge.com/tree/main/public/logos"
           >Open Source Pledge Member logo</a
         >
-        on your website and marketing materials if you wish. Thank you so much for
-        joining us in contributing to a healthy Open Source ecosystem that
+        on your website and marketing materials if you wish. Thank you so much
+        for joining us in contributing to a healthy Open Source ecosystem that
         supports maintainers.
       </p>
       <p>
@@ -169,7 +171,6 @@ import Button from "../components/Button.astro";
           >open an issue</a
         >, and the relevant member of our team will get back to you.
       </p>
-
     </Prose>
   </div>
 </Layout>


### PR DESCRIPTION
Sorry, I ran prettier over this a couple times and it reflowed for some reason, rough diff.

This removes references to _fiscal_ year.