### PR TITLE
Onboard Astral

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -1,1 +1,2 @@
 sentry,https://open.sentry.io/osspledge.json
+astral,https://astral.sh/static/osspledge.json


### PR DESCRIPTION
Additional branding available at https://brandpad.io/astral

And here's [a Google sheet](https://docs.google.com/spreadsheets/d/1-i0yP6FGvDC87RyW5_espC7W5824RNlIckE618Z6MLw/edit?gid=0#gid=0) itemizing our current sponsorships that are included in the fund. I'm adding it to our blog post (pending internal review):

<br />

<img width="905" alt="Screenshot 2024-08-27 at 7 04 29 PM" src="https://github.com/user-attachments/assets/7531c685-22ce-4ad7-84fa-15bee05ad44c">
