### PR TITLE
Add GitButler

### DIFF
--- a/members.csv
+++ b/members.csv
@@ -1,2 +1,3 @@
 sentry,https://open.sentry.io/osspledge.json
 astral,https://astral.sh/static/osspledge.json
+gitbutler,https://docs.gitbutler.com/oss/pledge.json


### PR DESCRIPTION
Just throwing GitButler into the mix here.

I do want to mention that it's a little difficult to join, technically. We were donating $6k/yr for the last year+, but technically to fit the definition, we needed a bit more. I tried to do it on Thanks.dev but they don't really have a way to immediately take a payment. So I sort of just topped up with a donation to Svelte and was like "that's last year, if the year ends at the end of the day today", 😂 

I set up monthly recurring donations that keep us in line going forward, but just a little feedback that it's somewhat difficult to be like "I want to join" and can just go online and easily donate to a nice spread of projects. Both GitHub Sponsors and Thanks.dev have big issues with this sort of use case.

Anyhow, assuming you all feel like we're in line (I believe we are), here is a repo to our brand assets for whatever you might want to use for marketing:

https://github.com/gitbutlerapp/gitbutler-brand-assets

And here is our blog post announcing (sort of a chicken/egg thing here saying we're joining in order to be accepted to join 🐔 🥚): https://blog.gitbutler.com/open-source-pledge-2024/

Let me know if that works. Thanks for all the effort @chadwhitacre and co!