### PR TITLE
Tweak a few things post-redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,3 @@ Open Source Pledge is brought to you by [Sentry][sentry] and [contributors][cont
 [osp]: https://osspledge.com/
 [restaurant]: https://openpath.chadwhitacre.com/2024/open-source-is-a-restaurant/
 [sentry]: https://sentry.io/welcome/
-
-## Governance and Structure
-
-We have four working groups and a steering committee comprised of working group leads.
-
-| Working Group       | Lead                                                     |
-| ------------------- | -------------------------------------------------------- |
-| Member Outreach     | [**@vladh**](https://vladh.net)                          |
-| Maintainer Outreach | [**@Ethan-Arrowood**](https://ethanarrowood.com/)        |
-| Marketing & Media   | [**@selviano**](https://github.com/selviano)             |
-| Design / Build      | [**@chadwhitacre**](https://chadwhitacre.com/)           |
-| Steering            | [**@chadwhitacre**](https://chadwhitacre.com/)           |

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -49,7 +49,7 @@ const { title, navless } = Astro.props;
     ) }
     <slot></slot>
     <footer class="container">
-      <span>Brought to you by <a class="sneaky" href="https://sentry.io">Sentry</a> and <a href="https://github.com/opensourcepledge/osspledge.com/graphs/contributors">contributors</a>.</span>
+      <span>Brought to you by <a class="sneaky" href="https://sentry.io/welcome/">Sentry</a> and <a class="sneaky" href="https://github.com/opensourcepledge/osspledge.com/graphs/contributors">contributors</a>.</span>
       <span><a class="sneaky" href="/join">Join</a></span>
       <span><a class="sneaky" href="/about">About</a></span>
       <span><a class="sneaky" href="/members">Members</a></span>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -49,10 +49,10 @@ const { title, navless } = Astro.props;
     ) }
     <slot></slot>
     <footer class="container">
-      <a class="sneaky" href="https://sentry.io">Brought to you by Sentry</a>
-      <a class="sneaky" href="/join">Join</a>
-      <a class="sneaky" href="/about">About</a>
-      <a class="sneaky" href="/members">Members</a>
+      <span>Brought to you by <a class="sneaky" href="https://sentry.io">Sentry</a> and <a href="https://github.com/opensourcepledge/osspledge.com/graphs/contributors">contributors</a>.</span>
+      <span><a class="sneaky" href="/join">Join</a></span>
+      <span><a class="sneaky" href="/about">About</a></span>
+      <span><a class="sneaky" href="/members">Members</a></span>
     </footer>
   </body>
 </html>
@@ -315,7 +315,7 @@ const { title, navless } = Astro.props;
   footer {
     padding: 2rem 0;
     text-align: center;
-    a {
+    span {
       display: inline-block;
       margin: 0 1rem;
     }

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -17,7 +17,7 @@ import Layout from "../layouts/Layout.astro";
 
       <p>Open Source Pledge is brought to you by <a href="https://sentry.io/welcome/">Sentry</a> and <a href="https://github.com/opensourcepledge/osspledge.com/graphs/contributors">contributors</a>.</p>
 
-      <p>We have four working groups and a steering committee comprised of working group leads.</p>
+      <p>We have four working groups and a steering group comprised of working group leads.</p>
 
       <table class="table--bordered">
         <tr>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -13,9 +13,9 @@ import Layout from "../layouts/Layout.astro";
     <Blob kind="solid-fill-04" top="90%" right="-20rem"></Blob>
 
     <section>
-      <h1>About Open Source Pledge</h1>
+      <h1>About the Pledge</h1>
 
-      <p>Open Source Pledge is brought to you by <a href="https://sentry.io">Sentry</a>.</p>
+      <p>Open Source Pledge is brought to you by <a href="https://sentry.io">Sentry</a> and <a href="https://github.com/opensourcepledge/osspledge.com/graphs/contributors">contributors</a>.</p>
 
       <p>We have four working groups and a steering committee comprised of working group leads.</p>
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,7 +15,7 @@ import Layout from "../layouts/Layout.astro";
     <section>
       <h1>About the Pledge</h1>
 
-      <p>Open Source Pledge is brought to you by <a href="https://sentry.io">Sentry</a> and <a href="https://github.com/opensourcepledge/osspledge.com/graphs/contributors">contributors</a>.</p>
+      <p>Open Source Pledge is brought to you by <a href="https://sentry.io/welcome/">Sentry</a> and <a href="https://github.com/opensourcepledge/osspledge.com/graphs/contributors">contributors</a>.</p>
 
       <p>We have four working groups and a steering committee comprised of working group leads.</p>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,8 +30,7 @@ import TextButton from "../components/TextButton.astro";
           </div>
         </div>
         <p
-          >Whether you're a CEO, CFO, CTO, or just a dev, chances are your company is building using OSS. It's time to
-          pledge back.</p
+          >Whether you're a CEO, CFO, CTO, or just a dev, chances are your company depends on Open Source software. It's time to pledge back.</p
         >
         <Button href="/join"
           >Join the Pledge</Button
@@ -44,14 +43,13 @@ import TextButton from "../components/TextButton.astro";
 
       <div class="highlight-box highlight-box--circled">
         <h3><div><span class="circled">1</span></div><span>Pay Open Source maintainers</span></h3>
-        <p>The minimum to participate is $2,000 per full-time equivalent employed developer per year.</p>
+        <p>The minimum to participate is $2,000 per year per developer at your company.</p>
       </div>
 
       <div class="highlight-box highlight-box--circled">
         <h3><div><span class="circled">2</span></div><span>Self-report annually</span></h3>
         <p
-          >Each year, create a blog post outlining your payments to maintainers, as well as your FTE developer
-          count.</p
+          >Each year, publish a blog post outlining your payments to maintainers.</p
         >
       </div>
     </section>

--- a/src/pages/members/index.astro
+++ b/src/pages/members/index.astro
@@ -15,7 +15,7 @@ import Leaderboard from "../../components/Leaderboard.astro";
 
     <section>
       <div class="text-center">
-        <h1>Member<br>groups</h1>
+        <h1>Member<br>Companies</h1>
       </div>
       <Leaderboard grouped={true}></Leaderboard>
     </section>


### PR DESCRIPTION
Follow-up to #65. Mostly word-smithing, also dedupes governance info (don't need it in README _and_ /about).