### PR TITLE
Fix heading fallback fonts

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -189,7 +189,7 @@ const { title, navless } = Astro.props;
     --color-text: white;
   }
   html {
-    font-family: Libre Franklin, system-ui, sans-serif;
+    font-family: Libre Franklin, sans-serif;
     font-size: 20px;
     line-height: 1.6;
     background-color: var(--color-bg);
@@ -204,7 +204,7 @@ const { title, navless } = Astro.props;
   h1, h2, h3, h4, h5, h6 {
     margin: 0;
     margin-bottom: 0.5em;
-    font-family: Azeret Mono, Courier New, Courier, monospace;
+    font-family: Azeret Mono, sans-serif;
   }
   p {
     margin: 1rem 0;


### PR DESCRIPTION
Azeret Mono is monospaced, but falling back to other monospaced fonts such as Courier does not give us the look we're going for, which is visible during loading on iOS:

![IMG_6985](https://github.com/user-attachments/assets/7ad580aa-eef7-4451-b10f-3524d398ee97)

It's better to just fall back to a sans-serif font, which makes the font swap almost imperceptible.

I've also removed usage of `system-ui` before `sans-serif`, so that we respect the user's choice of sans-serif font.