### PR TITLE
Randomise homepage members

### DIFF
--- a/src/components/Leaderboard.astro
+++ b/src/components/Leaderboard.astro
@@ -20,24 +20,32 @@ const members = await getMembers();
   {groupMembers(filterInactiveMembers(members)).map((groupMembers, idx) => groupMembers.length > 0 && <div>
     <h2>{formatDevGroupBounds(DEV_GROUP_BOUNDS[idx])}</h2>
     <table class="table--lr">
-      <tr>
-        <th>Name</th>
-        <th>$/dev in latest report</th>
-      </tr>
-      {sortMembers(groupMembers).map((member) =>
-        <LeaderboardMember member={member}></LeaderboardMember>
-      )}
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>$/dev in latest report</th>
+        </tr>
+      </thead>
+      <tbody>
+        {sortMembers(groupMembers).map((member) =>
+          <LeaderboardMember member={member}></LeaderboardMember>
+        )}
+      </tbody>
     </table>
   </div>)}
 </div> : (
   <table class="table--lr">
-    <tr>
-      <th>Name</th>
-      <th>$/dev in latest report</th>
-    </tr>
-    {sortMembers(filterInactiveMembers(members)).map((member) => <tr>
-      <LeaderboardMember member={member}></LeaderboardMember>
-    </tr>)}
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>$/dev in latest report</th>
+      </tr>
+    </thead>
+    <tbody>
+      {sortMembers(filterInactiveMembers(members)).map((member) => <tr>
+        <LeaderboardMember member={member}></LeaderboardMember>
+      </tr>)}
+    </tbody>
   </table>
 )}
 

--- a/src/components/Leaderboard.astro
+++ b/src/components/Leaderboard.astro
@@ -10,7 +10,7 @@ const { grouped } = Astro.props;
 
 import LeaderboardMember from "./LeaderboardMember.astro";
 import {
-  getMembers, formatDevGroupBounds, filterInactiveMembers, groupMembers, sortMembers, DEV_GROUP_BOUNDS
+  getMembers, formatDevGroupBounds, filterInactiveMembers, groupMembers, sortMembersByDollarsPerDev, DEV_GROUP_BOUNDS
 } from '../members.ts';
 
 const members = await getMembers();
@@ -27,7 +27,7 @@ const members = await getMembers();
         </tr>
       </thead>
       <tbody>
-        {sortMembers(groupMembers).map((member) =>
+        {sortMembersByDollarsPerDev(groupMembers).map((member) =>
           <LeaderboardMember member={member}></LeaderboardMember>
         )}
       </tbody>
@@ -42,7 +42,7 @@ const members = await getMembers();
       </tr>
     </thead>
     <tbody>
-      {sortMembers(filterInactiveMembers(members)).map((member) => <tr>
+      {sortMembersByDollarsPerDev(filterInactiveMembers(members)).map((member) => <tr>
         <LeaderboardMember member={member}></LeaderboardMember>
       </tr>)}
     </tbody>

--- a/src/components/MiniLeaderboard.astro
+++ b/src/components/MiniLeaderboard.astro
@@ -8,24 +8,40 @@ import {
 } from '../members.ts';
 
 const members = await getMembers();
+
+function shuffle(array: any[]) {
+    for (let i = array.length - 1; i >= 0; i--) {
+        let j = Math.floor(Math.random() * (i + 1));
+        let temp = array[i];
+        array[i] = array[j];
+        array[j] = temp;
+    }
+    return array;
+}
+
+const N_TO_SHOW = 5;
 ---
 
-<table class="table--lr">
-  <tr>
-    <th>Name</th>
-    <th>$/dev in latest report</th>
-  </tr>
-  {sortMembers(filterInactiveMembers(members)).slice(0, 5).map((member) => <tr>
-    <td>
-      <a class="sneaky" href={`/members/${member.id}`}>
-        <img src={member.data.urlSquareLogoWithBackground} alt={`The ${member.data.name} logo`}>
-        {member.data.name}
-      </div>
-    </td>
-    <td>
-      {fmtCurrency(getDollarsPerDev(member.data.annualReports[0]))}
-    </td>
-  </tr>)}
+<table class="mini-leaderboard table--lr">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>$/dev in latest report</th>
+    </tr>
+  </thead>
+  <tbody>
+    {shuffle(sortMembers(filterInactiveMembers(members))).map((member, idx) => <tr hidden={ idx >= N_TO_SHOW }>
+      <td>
+        <a class="sneaky" href={`/members/${member.id}`}>
+          <img src={member.data.urlSquareLogoWithBackground} alt={`The ${member.data.name} logo`}>
+          {member.data.name}
+        </div>
+      </td>
+      <td>
+        {fmtCurrency(getDollarsPerDev(member.data.annualReports[0]))}
+      </td>
+    </tr>)}
+  </tbody>
 </table>
 
 <style>
@@ -47,3 +63,25 @@ const members = await getMembers();
     padding: 0.25rem 0
   }
 </style>
+
+<script>
+  const N_TO_SHOW = 5;
+  const $miniLeaderboards = document.querySelectorAll<HTMLElement>('.mini-leaderboard');
+  $miniLeaderboards.forEach(($miniLeaderboard) => {
+    const $rows = $miniLeaderboard.querySelectorAll<HTMLElement>('tbody tr');
+    const rowIds = [...Array($rows.length).keys()];
+    let rowsToShow = [];
+    for (let i = 0; i < N_TO_SHOW; i++) {
+      const randomIdx = Math.round(Math.random() * (rowIds.length - 1));
+      rowsToShow.push(rowIds[randomIdx]);
+      rowIds.splice(randomIdx, 1);
+    }
+    $rows.forEach(($row, idx) => {
+      if (rowsToShow.includes(idx)) {
+        $row.hidden = false;
+      } else {
+        $row.hidden = true;
+      }
+    });
+  });
+</script>

--- a/src/components/MiniLeaderboard.astro
+++ b/src/components/MiniLeaderboard.astro
@@ -3,23 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  getMembers, filterInactiveMembers, sortMembers,
-  getDollarsPerDev, fmtCurrency
+  getMembers, filterInactiveMembers, getDollarsPerDev, fmtCurrency, sortMembersByDevs,
 } from '../members.ts';
 
-const members = await getMembers();
-
-function shuffle(array: any[]) {
-    for (let i = array.length - 1; i >= 0; i--) {
-        let j = Math.floor(Math.random() * (i + 1));
-        let temp = array[i];
-        array[i] = array[j];
-        array[j] = temp;
-    }
-    return array;
-}
-
-const N_TO_SHOW = 5;
+const N_TO_CHOOSE = 5;
+const members = sortMembersByDevs(filterInactiveMembers(await getMembers()));
 ---
 
 <table class="mini-leaderboard table--lr">
@@ -30,7 +18,7 @@ const N_TO_SHOW = 5;
     </tr>
   </thead>
   <tbody>
-    {shuffle(sortMembers(filterInactiveMembers(members))).map((member, idx) => <tr hidden={ idx >= N_TO_SHOW }>
+    {members.map((member, idx) => <tr hidden={idx >= N_TO_CHOOSE}>
       <td>
         <a class="sneaky" href={`/members/${member.id}`}>
           <img src={member.data.urlSquareLogoWithBackground} alt={`The ${member.data.name} logo`}>
@@ -65,20 +53,22 @@ const N_TO_SHOW = 5;
 </style>
 
 <script>
-  const N_TO_SHOW = 5;
+  const N_TO_CHOOSE = 5;
+  const PROBABILITY_TO_SKIP = 0.5;
+
   const $miniLeaderboards = document.querySelectorAll<HTMLElement>('.mini-leaderboard');
   $miniLeaderboards.forEach(($miniLeaderboard) => {
     const $rows = $miniLeaderboard.querySelectorAll<HTMLElement>('tbody tr');
-    const rowIds = [...Array($rows.length).keys()];
-    let rowsToShow = [];
-    for (let i = 0; i < N_TO_SHOW; i++) {
-      const randomIdx = Math.round(Math.random() * (rowIds.length - 1));
-      rowsToShow.push(rowIds[randomIdx]);
-      rowIds.splice(randomIdx, 1);
-    }
+    let nChosen = 0;
+    const nTotal = $rows.length;
     $rows.forEach(($row, idx) => {
-      if (rowsToShow.includes(idx)) {
+      const mustChoose = idx == 0 || (N_TO_CHOOSE - nChosen == nTotal - idx);
+      const mustNotChoose = nChosen == N_TO_CHOOSE;
+      if (mustNotChoose) {
+        $row.hidden = true;
+      } else if (mustChoose || Math.random() < PROBABILITY_TO_SKIP) {
         $row.hidden = false;
+        nChosen++;
       } else {
         $row.hidden = true;
       }

--- a/src/members.ts
+++ b/src/members.ts
@@ -105,9 +105,26 @@ export function groupMembers(members: MemberWithId[]): MemberWithId[][] {
 }
 
 /**
+ * Sorts members by the average number of devs in their latest annual report.
+ */
+export function sortMembersByDevs(members: MemberWithId[]): MemberWithId[] {
+  return members.toSorted((m1, m2) => {
+    if (m1.data.annualReports.length == 0) {
+      return 1;
+    }
+    if (m2.data.annualReports.length == 0) {
+      return -1;
+    }
+    const devs1 = m1.data.annualReports[0].averageNumberOfDevs;
+    const devs2 = m2.data.annualReports[0].averageNumberOfDevs;
+    return devs2 - devs1;
+  });
+}
+
+/**
  * Sorts members by the dollars per dev donated in their latest annual report.
  */
-export function sortMembers(members: MemberWithId[]): MemberWithId[] {
+export function sortMembersByDollarsPerDev(members: MemberWithId[]): MemberWithId[] {
   return members.toSorted((m1, m2) => {
     if (m1.data.annualReports.length == 0) {
       return 1;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -32,30 +32,34 @@ import Layout from "../layouts/Layout.astro";
         <p>We have four working groups and a steering group comprised of working group leads.</p>
 
         <table class="table--bordered">
-          <tr>
-            <th>Working Group</th>
-            <th>Lead</th>
-          </tr>
-          <tr>
-            <td>Member Outreach</td>
-            <td><a href="https://vladh.net">Vlad-Stefan Harbuz</a></td>
-          </tr>
-          <tr>
-            <td>Maintainer Outreach</td>
-            <td><a href="https://ethanarrowood.com/">Ethan Arrowood</a></td>
-          </tr>
-          <tr>
-            <td>Marketing &amp; Media</td>
-            <td><a href="https://github.com/selviano">Michael Selvidge</a></td>
-          </tr>
-          <tr>
-            <td>Design &amp; Build</td>
-            <td><a href="https://chadwhitacre.com/">Chad Whitacre</a></td>
-          </tr>
-          <tr>
-            <td>Steering</td>
-            <td><a href="https://chadwhitacre.com/">Chad Whitacre</a></td>
-          </tr>
+          <thead>
+            <tr>
+              <th>Working Group</th>
+              <th>Lead</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Member Outreach</td>
+              <td><a href="https://vladh.net">Vlad-Stefan Harbuz</a></td>
+            </tr>
+            <tr>
+              <td>Maintainer Outreach</td>
+              <td><a href="https://ethanarrowood.com/">Ethan Arrowood</a></td>
+            </tr>
+            <tr>
+              <td>Marketing &amp; Media</td>
+              <td><a href="https://github.com/selviano">Michael Selvidge</a></td>
+            </tr>
+            <tr>
+              <td>Design &amp; Build</td>
+              <td><a href="https://chadwhitacre.com/">Chad Whitacre</a></td>
+            </tr>
+            <tr>
+              <td>Steering</td>
+              <td><a href="https://chadwhitacre.com/">Chad Whitacre</a></td>
+            </tr>
+          </tbody>
         </table>
       </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -63,7 +63,7 @@ import TextButton from "../components/TextButton.astro";
       <section class="flex-center">
         <div>
           <div class="text-center">
-            <h2>Top orgs opening up</h2>
+            <h2>Some Member Companies</h2>
           </div>
 
           <MiniLeaderboard></MiniLeaderboard>

--- a/src/pages/members/[id].astro
+++ b/src/pages/members/[id].astro
@@ -59,30 +59,34 @@ export async function getStaticPaths() {
           </div>
 
           <table class="table--bordered table--lr">
-            <tr>
-              <th>Item</th>
-              <th>Amount ($)</th>
-            </tr>
-            <tr>
-              <td>Payments to Projects</td>
-              <td>{fmtCurrency(report.payments)}</td>
-            </tr>
-            <tr>
-              <td></td>
-              <td>= {fmtCurrency(getDollarsPerDev(report))} / dev</td>
-            </tr>
-            <tr>
-              <td>Value of Time</td>
-              <td>{fmtCurrency(report.monetaryValueOfTime)}</td>
-            </tr>
-            <tr>
-              <td>Value of Materials</td>
-              <td>{fmtCurrency(report.monetaryValueOfMaterials)}</td>
-            </tr>
-            <tr>
-              <td>Total</td>
-              <td>{fmtCurrency(getReportFullTotal(report))}</td>
-            </tr>
+            <thead>
+              <tr>
+                <th>Item</th>
+                <th>Amount ($)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Payments to Projects</td>
+                <td>{fmtCurrency(report.payments)}</td>
+              </tr>
+              <tr>
+                <td></td>
+                <td>= {fmtCurrency(getDollarsPerDev(report))} / dev</td>
+              </tr>
+              <tr>
+                <td>Value of Time</td>
+                <td>{fmtCurrency(report.monetaryValueOfTime)}</td>
+              </tr>
+              <tr>
+                <td>Value of Materials</td>
+                <td>{fmtCurrency(report.monetaryValueOfMaterials)}</td>
+              </tr>
+              <tr>
+                <td>Total</td>
+                <td>{fmtCurrency(getReportFullTotal(report))}</td>
+              </tr>
+            </tbody>
           </table>
           <div class="text-center">
             <TextButton href={report.url}>Read report</TextButton>


### PR DESCRIPTION
Here's the approach I took. The list of members is randomised serverside for good measure. A row is created in the `MiniLeaderboard` table for _each_ member, but only the first 5 members are not `hidden`. This increases network payload, but only marginally. Then, if Javascript is enabled, some Javascript code runs that calculates a set of 5 new indices of members to be shown. The appropriate members are then hidden/shown. This happens so quickly that it's unlikely to cause flashing because of a delay in executing JS, and it also gracefully degrades when JS is disabled, with members then being randomised on every build.