### PR TITLE
Fix type error for annual reports tuple

### DIFF
--- a/src/members.ts
+++ b/src/members.ts
@@ -130,7 +130,10 @@ function sortReportsForMember(member: MemberWithId): MemberWithId {
     ...member,
     data: {
       ...member.data,
-      annualReports: sortedReports,
+      annualReports: sortedReports as [
+        MemberReport,
+        ...MemberReport[],
+      ],
     },
   };
 }


### PR DESCRIPTION
Follow up to #105. The Zod definition expects a tuple with at least 1 element.

lmk if there's a better way to fix this — I haven't used Zod too much.